### PR TITLE
Change UserLocation's model formatted time to string type

### DIFF
--- a/src/app/location-feed/location-feed.component.ts
+++ b/src/app/location-feed/location-feed.component.ts
@@ -27,7 +27,7 @@ export class LocationFeedComponent implements OnInit {
   isInvalidCoordinate: boolean = false;
   isNoRecord: boolean = false;
 
-  userTime: Date;
+  userTime: string;
   userLongitude: number = 0;
   userLatitude: number = 0;
   userCity: string = '';

--- a/src/app/user-location.model.ts
+++ b/src/app/user-location.model.ts
@@ -2,7 +2,7 @@ export class UserLocation {
   constructor (
     public abbreviation: string,
     public countryName: string,
-    public formatted: Date,
+    public formatted: string,
     public gmtOffset: number,
     public status: string,
     public timestamp: number,


### PR DESCRIPTION
This PR was created because on deployment to GCP, Angular CLI was throwing up errors because it was trying to parse a Date object into a string object using the convertDateObject pipe from PR #1. 

This PR cleans up the remnant of the other PRs and the latest master has since been deployed.

![Screen Shot 2019-12-07 at 12 13 39 PM](https://user-images.githubusercontent.com/11153258/70380111-05170f80-18eb-11ea-9ff1-f0da39310c62.png)

